### PR TITLE
Fix error on fail YAML parse without exception

### DIFF
--- a/src/Form/YamlType.php
+++ b/src/Form/YamlType.php
@@ -38,7 +38,11 @@ class YamlType extends AbstractType
                 }
 
                 try {
-                    return Yaml::parse($optionsAsString);
+                    $val = Yaml::parse($optionsAsString);
+                    if (!is_array($val)) {
+                        throw new ParseException('Result is not a array');
+                    }
+                    return $val;
                 } catch (ParseException $e) {
                     throw new TransformationFailedException('Invalid YAML format', 0, $e);
                 }

--- a/src/Form/YamlType.php
+++ b/src/Form/YamlType.php
@@ -42,6 +42,7 @@ class YamlType extends AbstractType
                     if (!is_array($val)) {
                         throw new ParseException('Result is not a array');
                     }
+
                     return $val;
                 } catch (ParseException $e) {
                     throw new TransformationFailedException('Invalid YAML format', 0, $e);


### PR DESCRIPTION
Consider this code:

```php
$val = Symfony\Component\Yaml\Yaml::parse("data1:val1\r\ndata2:val2");
dump($val);
```

Result:
```
"data1:val1 data2:val2"
```

The input data is a wrong YAML but no exception has been throw. This fix check if the parse result is an array and throw exception if not a array.
