### PR TITLE
Not modified content filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 2.2.0
+* added `NotModifiedContentFilter` and a bunch of `FieldComparator` classes
+
 # version 2.1.0
 * contentWriter return created content
 

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         }
     },
     "require": {
-        "code-rhapsodie/dataflow-bundle": "^2.0 || dev-master",
+        "php": "^7.1",
+        "code-rhapsodie/dataflow-bundle": "^2.1 || dev-master",
         "ezsystems/ezplatform-admin-ui": "^1.0",
         "ezsystems/ezpublish-kernel": "^7.0"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,7 @@
 <phpunit
         backupGlobals="false"
         backupStaticAttributes="false"
-        bootstrap="Tests/bootstrap.php"
+        bootstrap="tests/bootstrap.php"
         convertErrorsToExceptions="true"
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
@@ -14,16 +14,16 @@
         <ini name="error_reporting" value="-1" />
     </php>
     <testsuites>
-        <testsuite name="Port tests suite">
-            <directory suffix="Test.php">./Tests</directory>
+        <testsuite name="EzDataflow tests suite">
+            <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist>
-            <directory>./</directory>
+            <directory>./src/</directory>
             <exclude>
-                <directory>Tests/</directory>
+                <directory>tests/</directory>
                 <directory>vendor/</directory>
             </exclude>
         </whitelist>

--- a/src/CodeRhapsodieEzDataflowBundle.php
+++ b/src/CodeRhapsodieEzDataflowBundle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CodeRhapsodie\EzDataflowBundle;
 
 use CodeRhapsodie\EzDataflowBundle\DependencyInjection\CodeRhapsodieEzDataflowExtension;
+use CodeRhapsodie\EzDataflowBundle\DependencyInjection\Compiler\FieldComparatorCompilerPass;
 use CodeRhapsodie\EzDataflowBundle\Security\PolicyProvider;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,6 +23,8 @@ class CodeRhapsodieEzDataflowBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+
+        $container->addCompilerPass(new FieldComparatorCompilerPass());
 
         /** @var EzPublishCoreExtension $eZExtension */
         $eZExtension = $container->getExtension('ezpublish');

--- a/src/Core/FieldComparator/AbstractFieldComparator.php
+++ b/src/Core/FieldComparator/AbstractFieldComparator.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeRhapsodie\EzDataflowBundle\Core\FieldComparator;
+
+use eZ\Publish\API\Repository\FieldTypeService;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\FieldType\Value;
+
+abstract class AbstractFieldComparator implements FieldComparatorInterface
+{
+    /** @var FieldTypeService */
+    private $fieldTypeService;
+
+    public function __construct(FieldTypeService $fieldTypeService)
+    {
+        $this->fieldTypeService = $fieldTypeService;
+    }
+
+    public function compare(Field $field, $hash): bool
+    {
+        $newValue = $this->fieldTypeService->getFieldType($field->fieldTypeIdentifier)->fromHash($hash);
+
+        return $this->compareValues($field->value, $newValue);
+    }
+
+    /**
+     * Returns true if values are equals, false otherwise
+     */
+    abstract protected function compareValues(Value $currentValue, Value $newValue): bool;
+}

--- a/src/Core/FieldComparator/DelegatorFieldComparator.php
+++ b/src/Core/FieldComparator/DelegatorFieldComparator.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeRhapsodie\EzDataflowBundle\Core\FieldComparator;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+
+class DelegatorFieldComparator implements FieldComparatorInterface
+{
+    /** @var FieldComparatorInterface[] */
+    private $delegates;
+
+    /**
+     * FieldComparator constructor.
+     */
+    public function __construct()
+    {
+        $this->delegates = [];
+    }
+
+    public function compare(Field $field, $hash): bool
+    {
+        if (isset($this->delegates[$field->fieldTypeIdentifier])) {
+            return $this->delegates[$field->fieldTypeIdentifier]->compare($field, $hash);
+        }
+
+        // No comparator to handle this field type, we assume the value is different.
+        return false;
+    }
+
+    public function registerDelegateFieldComparator(FieldComparatorInterface $typedFieldComparator, string $fieldTypeIdentifier): void
+    {
+        $this->delegates[$fieldTypeIdentifier] = $typedFieldComparator;
+    }
+}

--- a/src/Core/FieldComparator/FieldComparatorInterface.php
+++ b/src/Core/FieldComparator/FieldComparatorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeRhapsodie\EzDataflowBundle\Core\FieldComparator;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+
+interface FieldComparatorInterface
+{
+    /**
+     * @return bool true if identical, false otherwise
+     */
+    public function compare(Field $field, $hash): bool;
+}

--- a/src/Core/FieldComparator/MapLocationFieldComparator.php
+++ b/src/Core/FieldComparator/MapLocationFieldComparator.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeRhapsodie\EzDataflowBundle\Core\FieldComparator;
+
+use eZ\Publish\Core\FieldType\Value;
+
+class MapLocationFieldComparator extends AbstractFieldComparator
+{
+    protected function compareValues(Value $currentValue, Value $newValue): bool
+    {
+        return (string) $currentValue === (string) $newValue
+            && (float) $currentValue->longitude === (float) $newValue->longitude
+            && (float) $currentValue->latitude === (float) $newValue->latitude
+        ;
+    }
+}

--- a/src/Core/FieldComparator/MatrixFieldComparator.php
+++ b/src/Core/FieldComparator/MatrixFieldComparator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeRhapsodie\EzDataflowBundle\Core\FieldComparator;
+
+use eZ\Publish\Core\FieldType\Value;
+
+class MatrixFieldComparator extends AbstractFieldComparator
+{
+    protected function compareValues(Value $currentValue, Value $newValue): bool
+    {
+        if (count($currentValue->rows) !== count($newValue->rows)) {
+            return false;
+        }
+
+        foreach ($newValue->rows as $index => $row) {
+            if (count($currentValue->rows[$index]->getCells()) !== count($row->getCells())) {
+                return false;
+            }
+
+            if (!empty(array_diff_assoc($currentValue->rows[$index]->getCells(), $row->getCells()))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Core/FieldComparator/NovaSEOMetasFieldComparator.php
+++ b/src/Core/FieldComparator/NovaSEOMetasFieldComparator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeRhapsodie\EzDataflowBundle\Core\FieldComparator;
+
+use eZ\Publish\Core\FieldType\Value;
+
+class NovaSEOMetasFieldComparator extends AbstractFieldComparator
+{
+    protected function compareValues(Value $currentValue, Value $newValue): bool
+    {
+        $map = [];
+        foreach ($currentValue->metas as $meta) {
+            $map[$meta->getName()] = $meta->getContent();
+        }
+
+        foreach ($newValue->metas as $meta) {
+            if (!isset($map[$meta->getName()]) || $map[$meta->getName()] !== $meta->getContent()) {
+                return false;
+            }
+        }
+
+        return count($currentValue->metas) === count($newValue->metas);
+    }
+}

--- a/src/Core/FieldComparator/SimpleFieldComparator.php
+++ b/src/Core/FieldComparator/SimpleFieldComparator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeRhapsodie\EzDataflowBundle\Core\FieldComparator;
+
+use eZ\Publish\Core\FieldType\Value;
+
+class SimpleFieldComparator extends AbstractFieldComparator
+{
+    protected function compareValues(Value $currentValue, Value $newValue): bool
+    {
+        return (string) $currentValue === (string) $newValue;
+    }
+}

--- a/src/Core/FieldComparator/UrlFieldComparator.php
+++ b/src/Core/FieldComparator/UrlFieldComparator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeRhapsodie\EzDataflowBundle\Core\FieldComparator;
+
+use eZ\Publish\Core\FieldType\Value;
+
+class UrlFieldComparator extends AbstractFieldComparator
+{
+    protected function compareValues(Value $currentValue, Value $newValue): bool
+    {
+        return $currentValue->link === $newValue->link && $currentValue->text === $newValue->text;
+    }
+}

--- a/src/DependencyInjection/Compiler/FieldComparatorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FieldComparatorCompilerPass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeRhapsodie\EzDataflowBundle\DependencyInjection\Compiler;
+
+use CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\DelegatorFieldComparator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class FieldComparatorCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has(DelegatorFieldComparator::class)) {
+            return;
+        }
+
+        $delegatorDef = $container->findDefinition(DelegatorFieldComparator::class);
+
+        foreach ($container->findTaggedServiceIds('coderhapsodie.ezdataflow.field_comparator') as $id => $tags) {
+            foreach ($tags as $attributes) {
+                if (!isset($attributes['fieldType'])) {
+                    throw new \InvalidArgumentException(sprintf('Service "%s" must define the "fieldType" attribute on "coderhapsodie.ezdataflow.field_comparator" tags.', $id));
+                }
+
+                $delegatorDef->addMethodCall(
+                    'registerDelegateFieldComparator',
+                    [new Reference($id), $attributes['fieldType']]
+                );
+            }
+        }
+    }
+}

--- a/src/Filter/NotModifiedContentFilter.php
+++ b/src/Filter/NotModifiedContentFilter.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeRhapsodie\EzDataflowBundle\Filter;
+
+use CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\FieldComparatorInterface;
+use CodeRhapsodie\EzDataflowBundle\Model\ContentUpdateStructure;
+use eZ\Publish\API\Repository\ContentService;
+
+/**
+ * Filters ContentUpdateStructure that would not result in any actual changes in the content.
+ */
+class NotModifiedContentFilter
+{
+    /** @var ContentService */
+    private $contentService;
+
+    /** @var FieldComparatorInterface */
+    private $comparator;
+
+    public function __construct(ContentService $contentService, FieldComparatorInterface $comparator)
+    {
+        $this->contentService = $contentService;
+        $this->comparator = $comparator;
+    }
+
+    public function __invoke($data)
+    {
+        if (!$data instanceof ContentUpdateStructure) {
+            return $data;
+        }
+
+        if ($data->getId()) {
+            $content = $this->contentService->loadContent($data->getId(), [$data->getLanguageCode()]);
+        } else {
+            $content = $this->contentService->loadContentByRemoteId($data->getRemoteId(), [$data->getLanguageCode()]);
+        }
+
+        foreach ($data->getFields() as $identifier => $hash) {
+            $field = $content->getField($identifier, $data->getLanguageCode());
+            if ($field === null || !$this->comparator->compare($field, $hash)) {
+                // At least one field is different, continue the dataflow.
+                return $data;
+            }
+        }
+
+        // All fields are identical, filter this item out.
+        return false;
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: services/comparators.yaml }
+
 services:
     _defaults:
         public: false
@@ -124,3 +127,16 @@ services:
         public: false
         tags:
             - {name: ezplatform.tab, group: coderhapsodie-ezdataflow}
+
+    CodeRhapsodie\EzDataflowBundle\Filter\NotModifiedContentFilter:
+        arguments:
+            $contentService: '@eZ\Publish\API\Repository\ContentService'
+            $comparator: '@CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\FieldComparatorInterface'
+
+    CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\FieldComparatorInterface: '@CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\DelegatorFieldComparator'
+    CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\DelegatorFieldComparator:
+
+    CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\AbstractFieldComparator:
+        arguments:
+            $fieldTypeService: '@eZ\Publish\API\Repository\FieldTypeService'
+        abstract: true

--- a/src/Resources/config/services/comparators.yaml
+++ b/src/Resources/config/services/comparators.yaml
@@ -1,0 +1,42 @@
+services:
+    CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\SimpleFieldComparator:
+        parent: 'CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\AbstractFieldComparator'
+        tags:
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezauthor' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezboolean' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezcountry' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezdate' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezdatetime' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezemail' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezfloat' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezinteger' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezisbn' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezkeyword' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezobjectrelation' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezobjectrelationlist' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezrichtext' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezselection' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'eztext' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezstring' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'eztime' }
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'eztags' }
+
+    CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\UrlFieldComparator:
+        parent: 'CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\AbstractFieldComparator'
+        tags:
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezurl' }
+
+    CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\NovaSEOMetasFieldComparator:
+        parent: 'CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\AbstractFieldComparator'
+        tags:
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'novaseometas' }
+
+    CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\MatrixFieldComparator:
+        parent: 'CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\AbstractFieldComparator'
+        tags:
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezmatrix' }
+
+    CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\MapLocationFieldComparator:
+        parent: 'CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\AbstractFieldComparator'
+        tags:
+            - { name: 'coderhapsodie.ezdataflow.field_comparator', fieldType: 'ezgmaplocation' }

--- a/src/Writer/ContentWriter.php
+++ b/src/Writer/ContentWriter.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace CodeRhapsodie\EzDataflowBundle\Writer;
 
+use CodeRhapsodie\DataflowBundle\DataflowType\Writer\DelegateWriterInterface;
 use CodeRhapsodie\EzDataflowBundle\Core\Content\ContentCreatorInterface;
 use CodeRhapsodie\EzDataflowBundle\Core\Content\ContentUpdaterInterface;
 use CodeRhapsodie\EzDataflowBundle\Model\ContentCreateStructure;
 use CodeRhapsodie\EzDataflowBundle\Model\ContentStructure;
 use CodeRhapsodie\EzDataflowBundle\Model\ContentUpdateStructure;
-use CodeRhapsodie\DataflowBundle\DataflowType\Writer\WriterInterface;
 
-class ContentWriter extends RepositoryWriter implements WriterInterface
+class ContentWriter extends RepositoryWriter implements DelegateWriterInterface
 {
     /** @var ContentCreatorInterface */
     private $creator;
@@ -41,5 +41,13 @@ class ContentWriter extends RepositoryWriter implements WriterInterface
         if ($item instanceof ContentUpdateStructure) {
             return $this->updater->updateFromStructure($item);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($item): bool
+    {
+        return $item instanceof ContentStructure;
     }
 }

--- a/tests/Core/FieldComparator/DelegatorFieldComparatorTest.php
+++ b/tests/Core/FieldComparator/DelegatorFieldComparatorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace CodeRhapsodie\EzDataflowBundle\Tests\Core\FieldComparator;
+
+use CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\DelegatorFieldComparator;
+use CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\FieldComparatorInterface;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use PHPUnit\Framework\TestCase;
+
+class DelegatorFieldComparatorTest extends TestCase
+{
+    /** @var DelegatorFieldComparator */
+    private $delegatorFieldComparator;
+
+    protected function setUp(): void
+    {
+        $type1FieldComparatorMock = $this->createMock(FieldComparatorInterface::class);
+        $type1FieldComparatorMock->method('compare')->willReturnCallback(function (Field $field, $hash) {
+            return $hash === 'rightValue1';
+        });
+        $type2FieldComparatorMock = $this->createMock(FieldComparatorInterface::class);
+        $type2FieldComparatorMock->method('compare')->willReturnCallback(function (Field $field, $hash) {
+            return $hash === 'rightValue2';
+        });
+        $this->delegatorFieldComparator = new DelegatorFieldComparator();
+        $this->delegatorFieldComparator->registerDelegateFieldComparator($type1FieldComparatorMock, 'type1');
+        $this->delegatorFieldComparator->registerDelegateFieldComparator($type2FieldComparatorMock, 'type2');
+    }
+
+    /**
+     * @dataProvider fieldProvider
+     */
+    public function testField(string $type, bool $expected, $hash)
+    {
+        $field = new Field(['fieldTypeIdentifier' => $type]);
+        $return = $this->delegatorFieldComparator->compare($field, $hash);
+
+        $this->assertSame($expected, $return);
+    }
+
+    public function fieldProvider(): iterable
+    {
+        yield ['type1', true, 'rightValue1'];
+        yield ['type1', false, 'wrongValue'];
+        yield ['type2', true, 'rightValue2'];
+        yield ['type2', false, 'wrongValue'];
+        yield ['otherType', false, 'rightValue1'];
+    }
+}

--- a/tests/Filter/NotModifiedContentFilterTest.php
+++ b/tests/Filter/NotModifiedContentFilterTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeRhapsodie\EzDataflowBundle\Tests\Filter;
+
+use CodeRhapsodie\EzDataflowBundle\Core\FieldComparator\FieldComparatorInterface;
+use CodeRhapsodie\EzDataflowBundle\Filter\NotModifiedContentFilter;
+use CodeRhapsodie\EzDataflowBundle\Model\ContentUpdateStructure;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class NotModifiedContentFilterTest extends TestCase
+{
+    /** @var ContentService|MockObject */
+    private $contentServiceMock;
+
+    /** @var FieldComparatorInterface|MockObject */
+    private $comparatorMock;
+
+    /** @var NotModifiedContentFilter */
+    private $notModifiedContentFilter;
+
+    protected function setUp(): void
+    {
+        $this->contentServiceMock = $this->createMock(ContentService::class);
+        $this->comparatorMock = $this->createMock(FieldComparatorInterface::class);
+        $this->notModifiedContentFilter = new NotModifiedContentFilter($this->contentServiceMock, $this->comparatorMock);
+    }
+
+    public function testNotContentUpdateStructure()
+    {
+        $data = 'notAStruct';
+        $returnValue = ($this->notModifiedContentFilter)($data);
+
+        $this->assertSame($data, $returnValue);
+    }
+
+    public function testIdenticalContent()
+    {
+        $id = 10;
+        $field1 = 'field1';
+        $value1 = 'value1';
+        $field2 = 'field2';
+        $value2 = 'value2';
+        $contentField1 = new Field();
+        $contentField2 = new Field();
+        $data = ContentUpdateStructure::createForContentId($id, 'lang', [
+            $field1 => $value1,
+            $field2 => $value2,
+        ]);
+        $content = $this->createMock(Content::class);
+
+        $content
+            ->expects($this->exactly(2))
+            ->method('getField')
+            ->withConsecutive([$field1], [$field2])
+            ->willReturnOnConsecutiveCalls($contentField1, $contentField2)
+        ;
+        $this->contentServiceMock
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with($id)
+            ->willReturn($content)
+        ;
+        $this->comparatorMock
+            ->expects($this->exactly(2))
+            ->method('compare')
+            ->withConsecutive([$contentField1, $value1], [$contentField2, $value2])
+            ->willReturn(true)
+        ;
+
+        $return = ($this->notModifiedContentFilter)($data);
+
+        $this->assertFalse($return);
+    }
+
+    public function testDifferentContent()
+    {
+        $id = 10;
+        $field1 = 'field1';
+        $value1 = 'value1';
+        $field2 = 'field2';
+        $value2 = 'value2';
+        $field3 = 'field3';
+        $value3 = 'value3';
+        $contentField1 = new Field();
+        $contentField2 = new Field();
+        $data = ContentUpdateStructure::createForContentId($id, 'lang', [
+            $field1 => $value1,
+            $field2 => $value2,
+            $field3 => $value3,
+        ]);
+        $content = $this->createMock(Content::class);
+
+        $content
+            ->expects($this->exactly(2))
+            ->method('getField')
+            ->withConsecutive([$field1], [$field2])
+            ->willReturnOnConsecutiveCalls($contentField1, $contentField2)
+        ;
+        $this->contentServiceMock
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with($id)
+            ->willReturn($content)
+        ;
+        $this->comparatorMock
+            ->expects($this->exactly(2))
+            ->method('compare')
+            ->withConsecutive([$contentField1, $value1], [$contentField2, $value2])
+            ->willReturnOnConsecutiveCalls(true, false)
+        ;
+
+        $return = ($this->notModifiedContentFilter)($data);
+
+        $this->assertSame($data, $return);
+    }
+
+    public function testLoadEmptyByRemoteId()
+    {
+        $remoteId = 'abc';
+        $data = ContentUpdateStructure::createForContentRemoteId($remoteId, 'lang', []);
+
+        $this->contentServiceMock
+            ->expects($this->once())
+            ->method('loadContentByRemoteId')
+            ->with($remoteId)
+            ->willReturn(new Content())
+        ;
+        $return = ($this->notModifiedContentFilter)($data);
+
+        $this->assertFalse($return);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+
+// Skip autoloading if already done by phpunit alias (including from meta repo if this is vendor)
+if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+    return;
+}
+$autoloadFile = __DIR__ . '/../vendor/autoload.php';
+if (!file_exists($autoloadFile)) {
+    throw new RuntimeException('Install dependencies to run test suite.');
+}
+require_once $autoloadFile;


### PR DESCRIPTION
- [x] Add tests
- [x] Supports some more field types
- [x] Handle language
- [x] Update README

Provides a filter (step) to exclude `ContentUpdateStructure` which fields are the same as the published version of the content.

### Limitations:
- Some native field types (like files) **won't be supported** as there is no way to actually compare values
- For unsupported field types, values **will be assumed different**
- As comparison generates some overhead, especially for contents with a lot of fields, **do not use it if your data contains unsupported field types**

### Extensibility
Comparators for other field types can be added as tagged services.